### PR TITLE
Cellmap layout

### DIFF
--- a/ngff_zarr/cli.py
+++ b/ngff_zarr/cli.py
@@ -80,7 +80,7 @@ def _ngff_image_to_multiscales(live, ngff_image, args, progress, rich_dask_progr
         ngff_image.axes_units = unit_pairs
     if args.name:
         ngff_image.name = args.name
-    if args.layout:
+    if layout := args.layout:
         if layout not in ('itk', 'cellmap'):
             msg = (f"Invalid layout specified: {layout}." 
                    "Layout must be either 'itk' or 'cellmap'")
@@ -123,7 +123,7 @@ def main():
     processing_group.add_argument('-m', '--method', default="dask_image_gaussian", choices=methods_values, help="Downsampling method")
     processing_group.add_argument('-q', '--quiet', action='store_true', help='Do not display progress information')
     processing_group.add_argument('-l', '--local-cluster', action='store_true', help='Create a Dask Distributed LocalCluster. Better for large datasets.')
-    processing_group.add_argument('-layout', '--layout', action='store_true', help='Which layout to use. Must be either "itk" or "cellmap". Default is "itk"')
+    processing_group.add_argument('--layout', choices=('itk', 'cellmap'), default='itk', help='Which layout to use. Must be either "itk" or "cellmap". Default is "itk"')
     processing_group.add_argument('--input-backend', choices=conversion_backends_values, help='Input conversion backend')
     processing_group.add_argument('--memory-target', help='Memory limit, e.g. 4GB')
     processing_group.add_argument('--cache-dir', help='Directory to use for caching with large datasets')

--- a/ngff_zarr/cli.py
+++ b/ngff_zarr/cli.py
@@ -123,6 +123,7 @@ def main():
     processing_group.add_argument('-m', '--method', default="dask_image_gaussian", choices=methods_values, help="Downsampling method")
     processing_group.add_argument('-q', '--quiet', action='store_true', help='Do not display progress information')
     processing_group.add_argument('-l', '--local-cluster', action='store_true', help='Create a Dask Distributed LocalCluster. Better for large datasets.')
+    processing_group.add_argument('-layout', '--layout', action='store_true', help='Which layout to use. Must be either "itk" or "cellmap". Default is "itk"')
     processing_group.add_argument('--input-backend', choices=conversion_backends_values, help='Input conversion backend')
     processing_group.add_argument('--memory-target', help='Memory limit, e.g. 4GB')
     processing_group.add_argument('--cache-dir', help='Directory to use for caching with large datasets')

--- a/ngff_zarr/cli.py
+++ b/ngff_zarr/cli.py
@@ -80,6 +80,14 @@ def _ngff_image_to_multiscales(live, ngff_image, args, progress, rich_dask_progr
         ngff_image.axes_units = unit_pairs
     if args.name:
         ngff_image.name = args.name
+    if args.layout:
+        if layout not in ('itk', 'cellmap'):
+            msg = (f"Invalid layout specified: {layout}." 
+                   "Layout must be either 'itk' or 'cellmap'")
+            raise ValueError(msg)
+        layout = args.layout
+    else:
+        layout = 'cellmap'
 
     # Generate Multiscales
     cache = data.nbytes > config.memory_target
@@ -93,7 +101,7 @@ def _ngff_image_to_multiscales(live, ngff_image, args, progress, rich_dask_progr
             chunks = chunks[0]
         else:
             chunks = tuple(chunks)
-    multiscales = to_multiscales(ngff_image, method=method, progress=rich_dask_progress, chunks=chunks, cache=cache)
+    multiscales = to_multiscales(ngff_image, layout=layout, method=method, progress=rich_dask_progress, chunks=chunks, cache=cache)
     return multiscales
 
 

--- a/ngff_zarr/to_multiscales.py
+++ b/ngff_zarr/to_multiscales.py
@@ -197,7 +197,7 @@ def _large_image_serialization(image: NgffImage, progress: Optional[Union[NgffPr
 
 def to_multiscales(
     data: Union[NgffImage, ArrayLike, MutableMapping, str, ZarrArray],
-    layout: Literal['itk', 'cellmap'] = 'cellmap',
+    layout: Literal['itk', 'cellmap'] = 'itk',
     scale_factors: Union[int, Sequence[Union[Dict[str, int], int]]] = 128,
     method: Optional[Methods] = None,
     chunks: Optional[
@@ -217,7 +217,7 @@ def to_multiscales(
     data: NgffImage, ArrayLike, ZarrArray, MutableMapping, str
         Multi-dimensional array that provides the image pixel values, or image pixel values + image metadata when an NgffImage.
 
-    layout: str, must be either 'cellmap' or 'itk'. Default is 'cellmap'.
+    layout: str, must be either 'cellmap' or 'itk'. Default is 'itk'.
         Determines the on-disk layout for the multiscale data. 
         
         If 'itk' is chosen, each scale level will be stored in a Zarr array in a 

--- a/ngff_zarr/to_multiscales.py
+++ b/ngff_zarr/to_multiscales.py
@@ -197,6 +197,7 @@ def _large_image_serialization(image: NgffImage, progress: Optional[Union[NgffPr
 
 def to_multiscales(
     data: Union[NgffImage, ArrayLike, MutableMapping, str, ZarrArray],
+    layout: Literal['itk', 'cellmap'] = 'cellmap',
     scale_factors: Union[int, Sequence[Union[Dict[str, int], int]]] = 128,
     method: Optional[Methods] = None,
     chunks: Optional[
@@ -215,6 +216,29 @@ def to_multiscales(
 
     data: NgffImage, ArrayLike, ZarrArray, MutableMapping, str
         Multi-dimensional array that provides the image pixel values, or image pixel values + image metadata when an NgffImage.
+
+    layout: str, must be either 'cellmap' or 'itk'. Default is 'cellmap'.
+        Determines the on-disk layout for the multiscale data. 
+        
+        If 'itk' is chosen, each scale level will be stored in a Zarr array in a 
+        subgroup of the multiscale group. 
+        
+        For example, if the multiscale group is called 'foo', then choosing the 'itk'
+        layout will result arrays with paths like 
+        `foo/scale0/image` 
+        `foo/scale1/image`
+
+        Additionally, an extra piece of metadata will be added to each of the `scaleX` 
+        groups that facilitates compatibility with the python library Xarray.
+
+        If 'ngff' is chosen, then storage will use the layout given as an example in the
+        OME-NGFF specification, with one modification: instead of saving arrays with 
+        names like 0,1, etc, arrays will be saved with names that are prefixed by 's'. 
+
+        For example, if the multiscale group is called 'foo', then choosing the 'ngff'
+        layout will result arrays with paths like 
+        `foo/s0` 
+        `foo/s1`  
 
     scale_factors : int of minimum length, int per scale or dict of spatial dimension int's per scale
         If a single integer, scale factors in spatial dimensions will be increased by a factor of two until this minimum length is reached.
@@ -316,7 +340,14 @@ def to_multiscales(
 
     datasets = []
     for index, image in enumerate(images):
-        path = f"scale{index}/{ngff_image.name}"
+        if layout == 'itk':
+            path = f"scale{index}/{ngff_image.name}"
+        elif layout == 'cellmap':
+            path = f"s{index}"
+        else:
+            msg = (f"Invalid layout specified: {layout}." 
+                   "Layout must be either 'itk' or 'cellmap'")
+            raise ValueError(msg)
         scale = []
         for dim in image.dims:
             if dim in image.scale:

--- a/ngff_zarr/to_ngff_zarr.py
+++ b/ngff_zarr/to_ngff_zarr.py
@@ -72,9 +72,16 @@ def to_ngff_zarr(
         image = next_image
         arr = image.data
         path = multiscales.metadata.datasets[index].path
-        array_dims_group = root.create_group(str(PurePosixPath(path).parent))
-        array_dims_group.attrs["_ARRAY_DIMENSIONS"] = image.dims
-
+        num_subgroups = len(PurePosixPath(path).parts) - 1
+        if num_subgroups == 0:
+            pass
+        elif num_subgroups == 1:
+            array_dims_group = root.create_group(str(PurePosixPath(path).parent))
+            array_dims_group.attrs["_ARRAY_DIMENSIONS"] = image.dims
+        else:
+            msg = (f"Only one level of subgrouping is allowed. Based on the path {path}"
+                   f" {num_subgroups} were requested.")
+            raise ValueError(msg)
         if index > 0 and index < nscales - 1:
             dim_factors = _dim_scale_factors(dims, multiscales.scale_factors[index], previous_dim_factors)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,17 @@ ngff-zarr = "ngff_zarr.cli:main"
 [tool.hatch.version]
 path = "ngff_zarr/__about__.py"
 
+[tool.hatch.envs.cli]
+dependencies = [
+    "dask-image",
+    "dask[distributed]",
+    "itk-filtering>=5.3.0",
+    "itk-io>=5.3.0",
+    "imageio",
+    "tifffile",
+
+]
+
 [tool.hatch.envs.test]
 dependencies = [
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,23 @@ ngff-zarr = "ngff_zarr.cli:main"
 [tool.hatch.version]
 path = "ngff_zarr/__about__.py"
 
+[tool.hatch.envs.test]
+dependencies = [
+  "pytest",
+  "pooch",
+  "itkwasm",
+  "itk-io>=5.3.0",
+  "itk-filtering>=5.3.0",
+  "tifffile",
+  "coverage[toml]",
+  "pytest-cov",
+  "dask-image"
+]
+
+[tool.hatch.envs.test.scripts]
+run-coverage = "pytest --cov-config=pyproject.toml --cov=pkg --cov=tests"
+run = "run-coverage --no-cov"
+
 [project.optional-dependencies]
 dask-image = [
     "dask-image",

--- a/test/test_from_ngff_zarr.py
+++ b/test/test_from_ngff_zarr.py
@@ -11,7 +11,7 @@ def test_gaussian_isotropic_scale_factors(input_images):
     dataset_name = "cthead1"
     image = input_images[dataset_name]
     baseline_name = "2_4/DASK_IMAGE_GAUSSIAN.zarr"
-    multiscales = to_multiscales(image, [2, 4], method=Methods.DASK_IMAGE_GAUSSIAN)
+    multiscales = to_multiscales(image, scale_factors=[2, 4], method=Methods.DASK_IMAGE_GAUSSIAN)
     # store_new_multiscales(dataset_name, f'{baseline_name}', multiscales)
     verify_against_baseline(dataset_name, baseline_name, multiscales)
 

--- a/test/test_to_ngff_zarr_dask_image.py
+++ b/test/test_to_ngff_zarr_dask_image.py
@@ -8,7 +8,7 @@ def test_gaussian_isotropic_scale_factors(input_images):
     dataset_name = "cthead1"
     image = input_images[dataset_name]
     baseline_name = "2_4/DASK_IMAGE_GAUSSIAN.zarr"
-    multiscales = to_multiscales(image, [2, 4], method=Methods.DASK_IMAGE_GAUSSIAN)
+    multiscales = to_multiscales(image, scale_factors=[2, 4], method=Methods.DASK_IMAGE_GAUSSIAN)
     # store_new_multiscales(dataset_name, baseline_name, multiscales)
     verify_against_baseline(dataset_name, baseline_name, multiscales)
 
@@ -19,7 +19,7 @@ def test_gaussian_isotropic_scale_factors(input_images):
     dataset_name = "brain_two_components"
     image = input_images[dataset_name]
     baseline_name = "2_4/DASK_IMAGE_GAUSSIAN.zarr"
-    multiscales = to_multiscales(image, [2, 4], method=Methods.DASK_IMAGE_GAUSSIAN)
+    multiscales = to_multiscales(image, scale_factors=[2, 4], method=Methods.DASK_IMAGE_GAUSSIAN)
     verify_against_baseline(dataset_name, baseline_name, multiscales)
 
 #     dataset_name = "cthead1"

--- a/test/test_to_ngff_zarr_itk.py
+++ b/test/test_to_ngff_zarr_itk.py
@@ -8,7 +8,7 @@ def test_bin_shrink_isotropic_scale_factors(input_images):
     dataset_name = "cthead1"
     image = input_images[dataset_name]
     baseline_name = "2_4/ITK_BIN_SHRINK.zarr"
-    multiscales = to_multiscales(image, [2, 4], method=Methods.ITK_BIN_SHRINK)
+    multiscales = to_multiscales(image, scale_factors=[2, 4], method=Methods.ITK_BIN_SHRINK)
     # store_new_multiscales(dataset_name, baseline_name, multiscales)
     verify_against_baseline(dataset_name, baseline_name, multiscales)
 
@@ -20,7 +20,7 @@ def test_gaussian_isotropic_scale_factors(input_images):
     dataset_name = "cthead1"
     image = input_images[dataset_name]
     baseline_name = "2_4/ITK_GAUSSIAN.zarr"
-    multiscales = to_multiscales(image, [2, 4], method=Methods.ITK_GAUSSIAN)
+    multiscales = to_multiscales(image, scale_factors=[2, 4], method=Methods.ITK_GAUSSIAN)
     verify_against_baseline(dataset_name, baseline_name, multiscales)
 
     baseline_name = "auto/ITK_GAUSSIAN.zarr"


### PR DESCRIPTION
This adds support for the "cellmap layout" for multiscale groups, e.g. `multiscale_group/s0/`, `multiscale_group/s1`, etc. The original layout produced by this tool, hereafter termed the "itk layout", is the default layout. The layout can be specified at the command line via the `--layout` argument, e.g. `--layout=cellmap` 

I also made some changes to the hatch config to make tests and the cli runnable via `hatch run`. These changes might be stupid garbage, I don't really know how to use hatch 🤷‍♂️ 

the cellmap layout is not currently tested at all in the test suite, that's on the to-do list.